### PR TITLE
Small fixes to achieve Python 3 compatibility

### DIFF
--- a/aes_gcm.py
+++ b/aes_gcm.py
@@ -100,7 +100,7 @@ class AES_GCM:
 
         tag = 0
         assert len(data) % 16 == 0
-        for i in range(len(data) / 16):
+        for i in range(len(data) // 16):
             tag ^= bytes_to_long(data[i * 16: (i + 1) * 16])
             tag = self.__times_auth_key(tag)
             # print 'X\t', hex(tag)
@@ -204,16 +204,17 @@ if __name__ == '__main__':
                  b'\x3d\x58\xe0\x91'
     auth_tag = 0x5bc94fbc3221a5db94fae95ae7121a47
 
-    print 'plaintext:', hex(bytes_to_long(plaintext))
+    print('plaintext:', hex(bytes_to_long(plaintext)))
 
     my_gcm = AES_GCM(master_key)
     encrypted, new_tag = my_gcm.encrypt(init_value, plaintext, auth_data)
-    print 'encrypted:', hex(bytes_to_long(encrypted))
-    print 'auth tag: ', hex(new_tag)
+    print('encrypted:', hex(bytes_to_long(encrypted)))
+    print('auth tag: ', hex(new_tag))
 
     try:
         decrypted = my_gcm.decrypt(init_value, encrypted,
                 new_tag + 1, auth_data)
     except InvalidTagException:
         decrypted = my_gcm.decrypt(init_value, encrypted, new_tag, auth_data)
-        print 'decrypted:', hex(bytes_to_long(decrypted))
+        print('decrypted:', hex(bytes_to_long(decrypted)))
+

--- a/test.py
+++ b/test.py
@@ -137,11 +137,11 @@ if __name__ == '__main__':
                 tag != test_data['auth_tag'] or \
                 decrypted != test_data['plaintext']:
             num_failures += 1
-            print 'This test case failed:'
+            print('This test case failed:')
             pprint(test_data)
-            print
+            print()
 
     if num_failures == 0:
-        print 'All test cases passed!'
+        print('All test cases passed!')
     else:
-        print num_failures, 'test cases failed in total.'
+        print(num_failures, 'test cases failed in total.')


### PR DESCRIPTION
Ran '2to3' migration tool, which mostly added parenthesis to 'print' statements.
aes_gcm.py also needed the "//" operator for integer division in __ghash
("/" led to type error (float vs int)).
